### PR TITLE
Overclock with PSRAM

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,6 +37,8 @@ jobs:
           ./fetch-rom-dsk.sh
           ./fruitjam-build.sh -m 4096
           ./fruitjam-build.sh -m 4096 -v
+          ./fruitjam-build.sh -m 4096 -o
+          ./fruitjam-build.sh -m 4096 -v -o
           ./fruitjam-build.sh -m 400
           ./fruitjam-build.sh -m 400 -v
           ./fruitjam-build.sh -m 400 -o

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,9 +23,6 @@ jobs:
       with:
         release: '13.2.Rel1'
 
-    - name: install sdl
-      run: sudo apt-get update && sudo apt-get install -y eatmydata && sudo eatmydata apt-get install -y libsdl2-dev
-
     - name: get submodules
       run: git submodule update --init --recursive
 

--- a/src/clocking.c
+++ b/src/clocking.c
@@ -31,7 +31,7 @@ static void __no_inline_not_in_flash_func(set_qmi_timing)() {
 #endif
 
 #ifndef RP2350_PSRAM_MAX_SCK_HZ
-#define RP2350_PSRAM_MAX_SCK_HZ (109000000)
+#define RP2350_PSRAM_MAX_SCK_HZ (66777777)
 #endif
 
 #define SEC_TO_FS 1000000000000000ll
@@ -62,6 +62,7 @@ static void __no_inline_not_in_flash_func(set_psram_timing)(void) {
 
     printf("syshz=%u\n", sysHz);
     printf("Max Select: %d, Min Deselect: %d, clock divider: %d\n", maxSelect, minDeselect, clockDivider);
+    printf("PSRAM clock rate %.1fMHz\n", (float)sysHz / clockDivider / 1e6);
 
     qmi_hw->m[1].timing = QMI_M1_TIMING_PAGEBREAK_VALUE_1024 << QMI_M1_TIMING_PAGEBREAK_LSB | // Break between pages.
                           3 << QMI_M1_TIMING_SELECT_HOLD_LSB | // Delay releasing CS for 3 extra system cycles.
@@ -142,10 +143,6 @@ void overclock(enum clk_sys_speed clk_sys_div, uint32_t bit_clk_khz) {
 	stdio_init_all();
     set_psram_timing();
 #define SHOW_CLK(i) printf("clk_get_hz(%s) -> %u\n", #i, clock_get_hz(i));
-        SHOW_CLK(clk_gpout0);
-        SHOW_CLK(clk_gpout1);
-        SHOW_CLK(clk_gpout2);
-        SHOW_CLK(clk_gpout3);
         SHOW_CLK(clk_ref);
         SHOW_CLK(clk_sys);
         SHOW_CLK(clk_peri);

--- a/src/main.c
+++ b/src/main.c
@@ -472,27 +472,40 @@ static void __no_inline_not_in_flash_func(setup_psram)(void) {
 
 int     main()
 {
-#if defined(OVERCLOCK) && OVERCLOCK+0
+        setup_psram();
+#if OVERCLOCK
         overclock(CLK_SYS_264MHZ, 252000);
 #endif
-        // set_sys_clock_khz(250*1000, true);
-
-        setup_psram();
-
 	stdio_init_all();
-        io_init();
 
-#define SHOW_CLK(i) printf("clk_get_hz(%s) -> %u\n", #i, clock_get_hz(i));
-        SHOW_CLK(clk_gpout0);
-        SHOW_CLK(clk_gpout1);
-        SHOW_CLK(clk_gpout2);
-        SHOW_CLK(clk_gpout3);
-        SHOW_CLK(clk_ref);
-        SHOW_CLK(clk_sys);
-        SHOW_CLK(clk_peri);
-        SHOW_CLK(clk_hstx);
-        SHOW_CLK(clk_usb);
-        SHOW_CLK(clk_adc);
+printf("psram size %u\n", _psram_size);
+
+#ifndef RAM_TEST
+#define RAM_TEST (0)
+#endif
+
+#if RAM_TEST
+for(int pass=0; pass<10; pass++) {
+    uint8_t acc = 1;
+    for(int i=0; i < _psram_size; i++) {
+        umac_ram[i] = acc;
+        acc = acc * 13 + 21;
+    }
+
+    acc = 1;
+    for(int i=0; i < _psram_size; i++) {
+        uint8_t ri = umac_ram[i];
+        if(ri != acc) {
+            panic("[%08x] Stored %02x read %02x", i, acc, ri);
+        }
+        acc = acc * 13 + 21;
+    }
+
+    printf("ram test pass %d OK\n", pass);
+}
+#endif
+
+        io_init();
 
 #if ENABLE_AUDIO
         audio_setup();


### PR DESCRIPTION
In order to do so, the PSRAM is actually being underclocked compared to the existing specification (66MHz vs 109MHz).

Now it passes a simple RAM test and also reaches a MacOS desktop.

Is it faster? no idea!