### PR TITLE
Allow PSRAM QSPI > 84 MHz by enabling burst wrap mode.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -395,14 +395,25 @@ static void __no_inline_not_in_flash_func(setup_psram)(void) {
     }
 
     // RESETEN, RESET and quad enable
-    for (uint8_t i = 0; i < 3; i++) {
+    for (uint8_t i = 0; i < 4; i++) {
         qmi_hw->direct_csr |= QMI_DIRECT_CSR_ASSERT_CS1N_BITS;
-        if (i == 0) {
-            qmi_hw->direct_tx = 0x66;
-        } else if (i == 1) {
-            qmi_hw->direct_tx = 0x99;
-        } else {
-            qmi_hw->direct_tx = 0x35;
+        switch (i) {
+            case 0:
+                // RESETEN
+                qmi_hw->direct_tx = 0x66;
+                break;
+            case 1:
+                // RESET
+                qmi_hw->direct_tx = 0x99;
+                break;
+            case 2:
+                // Quad enable
+                qmi_hw->direct_tx = 0x35;
+                break;
+            case 3:
+                // Toggle wrap boundary mode
+                qmi_hw->direct_tx = 0xc0;
+                break;
         }
         while ((qmi_hw->direct_csr & QMI_DIRECT_CSR_BUSY_BITS) != 0) {
         }


### PR DESCRIPTION
To increase PSRAM QSPI clock beyond 84 MHz, the wrap boundary toggle must be set.

This allows QSPI clocking up to 133/144 MHz. See sections 4 and 5.4 of [ESP-PSRAM64 ESP-PSRAM64H Datasheet](https://cdn-shop.adafruit.com/product-files/4677/4677_esp-psram64_esp-psram64h_datasheet_en.pdf).

NB: This update will not affect operation at lower QSPI clock rates. The XIP controller is already programmed to break at 1K page boundaries.