### PR TITLE
Support PSRAM QSPI CLK up to 133MHz

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,6 +37,8 @@ jobs:
           ./fetch-rom-dsk.sh
           ./fruitjam-build.sh -m 4096
           ./fruitjam-build.sh -m 4096 -v
+          ./fruitjam-build.sh -m 4096 -o
+          ./fruitjam-build.sh -m 4096 -v -o
           ./fruitjam-build.sh -m 400
           ./fruitjam-build.sh -m 400 -v
           ./fruitjam-build.sh -m 400 -o

--- a/src/main.c
+++ b/src/main.c
@@ -395,14 +395,25 @@ static void __no_inline_not_in_flash_func(setup_psram)(void) {
     }
 
     // RESETEN, RESET and quad enable
-    for (uint8_t i = 0; i < 3; i++) {
+    for (uint8_t i = 0; i < 4; i++) {
         qmi_hw->direct_csr |= QMI_DIRECT_CSR_ASSERT_CS1N_BITS;
-        if (i == 0) {
-            qmi_hw->direct_tx = 0x66;
-        } else if (i == 1) {
-            qmi_hw->direct_tx = 0x99;
-        } else {
-            qmi_hw->direct_tx = 0x35;
+        switch (i) {
+            case 0:
+                // RESETEN
+                qmi_hw->direct_tx = 0x66;
+                break;
+            case 1:
+                // RESET
+                qmi_hw->direct_tx = 0x99;
+                break;
+            case 2:
+                // Quad enable
+                qmi_hw->direct_tx = 0x35;
+                break;
+            case 3:
+                // Toggle wrap boundary mode
+                qmi_hw->direct_tx = 0xc0;
+                break;
         }
         while ((qmi_hw->direct_csr & QMI_DIRECT_CSR_BUSY_BITS) != 0) {
         }


### PR DESCRIPTION
Support for PSRAM QSPI CLK up to 133MHz. Does the following:

- Activates PSRAM burst block wrapping mode during PSRAM initialization using the toggle wrap mode command (0xc0). This setting, in combination with XIP timing parameter `QMI_M1_TIMING_PAGEBREAK_VALUE_1024`, allows the PSRAM to operate with a QSPI CLK up to 133MHz.
- Sets PSRAM XIP timing parameter `QMI_M1_TIMING_RXDELAY` to a value close to 3.33ns. At higher QSPI CLK values this inserts a delay between the rising edge of the QSPI CLK and RX sampling.
- Adds a test for proper PSRAM operation to start-up.