### PR TITLE
Support bigger screen resolutions including 1280x720 "HD" 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,6 +39,8 @@ jobs:
           ./fruitjam-build.sh -m 4096 -v
           ./fruitjam-build.sh -m 4096 -o
           ./fruitjam-build.sh -m 4096 -v -o
+          ./fruitjam-build.sh -m 4096 -o -W800 -H480
+          ./fruitjam-build.sh -m 4096 -o -W1280 -H720
           ./fruitjam-build.sh -m 400
           ./fruitjam-build.sh -m 400 -v
           ./fruitjam-build.sh -m 400 -o

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ set(DISC_IMAGE ${CMAKE_CURRENT_SOURCE_DIR}/umac0ro.img CACHE FILEPATH "Built-in 
 if (USE_HSTX)
    add_compile_definitions(USE_VGA_RES=1)
    add_compile_definitions(HSTX_CKP=${HSTX_CKP} HSTX_D0P=${HSTX_D0P} HSTX_D1P=${HSTX_D1P} HSTX_D2P=${HSTX_D2P})
-   set(VIDEO_SRC src/video_hstx.c)
+   set(VIDEO_SRC src/video_hstx.c src/gtf.c)
 else()
   add_compile_definitions(GPIO_VID_BASE=${VIDEO_PIN})
   set(VIDEO_SRC src/video_vga.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,6 @@ set(HSTX_D2P 19 CACHE STRING "HSTX D2+ PIN")
 option(OVERCLOCK "Overclock to 264MHz (known incompatible with psram)" OFF)
 
 # Options for analog VGA output
-option(USE_VGA_RES "Video uses VGA (640x480) resolution" OFF)
 set(VIDEO_PIN 18 CACHE STRING "VGA Video GPIO base pin (followed by VS, CLK, HS)")
 
 option(USE_PSRAM "Locate main Mac ram in PSRAM (only for rp2350 / pico 2)" OFF)
@@ -78,7 +77,6 @@ set(MEMSIZE 128 CACHE STRING "Memory size, in KB")
 set(DISC_IMAGE ${CMAKE_CURRENT_SOURCE_DIR}/umac0ro.img CACHE FILEPATH "Built-in disk image")
 
 if (USE_HSTX)
-   add_compile_definitions(USE_VGA_RES=1)
    add_compile_definitions(HSTX_CKP=${HSTX_CKP} HSTX_D0P=${HSTX_D0P} HSTX_D1P=${HSTX_D1P} HSTX_D2P=${HSTX_D2P})
    set(VIDEO_SRC src/video_hstx.c src/gtf.c)
 else()
@@ -93,18 +91,13 @@ else()
   set(OPT_OC "")
 endif()
 
-if (USE_VGA_RES)
- add_compile_definitions(USE_VGA_RES=1)
- add_compile_definitions(DISP_WIDTH=640)
- add_compile_definitions(DISP_HEIGHT=480)
- set(RES "640x480")
- set(RESFLAG "-v")
-else()
- add_compile_definitions(DISP_WIDTH=512)
- add_compile_definitions(DISP_HEIGHT=342)
- set(RES "512x342")
- set(RESFLAG "")
-endif()
+set(MIRROR_FRAMEBUFFER 0 CACHE STRING "Whether to use a framebuffer mirror")
+set(DISP_WIDTH 512 CACHE STRING "Display width, in pixels")
+set(DISP_WIDTH 342 CACHE STRING "Display width, in pixels")
+add_compile_definitions(MIRROR_FRAMEBUFFER=${MIRROR_FRAMEBUFFER})
+add_compile_definitions(DISP_WIDTH=${DISP_WIDTH})
+add_compile_definitions(DISP_HEIGHT=${DISP_HEIGHT})
+set(RES "${DISP_WIDTH}x${DISP_HEIGHT}")
 
 if (USE_PSRAM)
   add_compile_definitions(PIN_PSRAM_CS=${PSRAM_CS} USE_PSRAM=1)
@@ -203,7 +196,7 @@ if (TARGET tinyusb_device)
   # The umac sources need to prepare Musashi (some sources are generated):
   add_custom_command(OUTPUT incbin/umac-rom.h
     COMMAND echo "*** Patching ROM ***"
-    COMMAND set -xe && mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/incbin && make -C ${UMAC_PATH} patcher && ${UMAC_PATH}/patcher ${RESFLAG} -m ${MEMSIZE} -r "${CMAKE_CURRENT_LIST_DIR}/rom.bin" -w ${CMAKE_CURRENT_BINARY_DIR}/incbin/umac-rom.h
+    COMMAND set -xe && mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/incbin && make -C ${UMAC_PATH} DEBUG=1 patcher && ${UMAC_PATH}/patcher -w ${DISP_WIDTH} -h ${DISP_HEIGHT} -m ${MEMSIZE} -r "${CMAKE_CURRENT_LIST_DIR}/rom.bin" -o ${CMAKE_CURRENT_BINARY_DIR}/incbin/umac-rom.h
     )
   add_custom_target(prepare_rom
     DEPENDS incbin/umac-rom.h

--- a/fruitjam-build.sh
+++ b/fruitjam-build.sh
@@ -2,10 +2,11 @@
 set -e
 
 # Some configurations that actually work at the time I committed this:
-# ./fruitjam-build.sh  -v         # vga resolution, no psram, 128KiB
-# ./fruitjam-build.sh  -v -m448   # vga resolution, no psram,  448KiB
-# ./fruitjam-build.sh  -m4096     # 512x342 resolution, psram, 4096KiB
-# ./fruitjam-build.sh  -d disk.img  # specify disk image
+# ./fruitjam-build.sh  -v              # 640x480 "vga" resolution, no psram, 128KiB
+# ./fruitjam-build.sh  -v -m448        # 640x480 "vga" resolution, no psram, 448KiB
+# ./fruitjam-build.sh  -m4096          # 512x342 resolution, psram, 4096KiB
+# ./fruitjam-build.sh  -d disk.img     # specify disk image
+# ./fruitjam-build.sh  -W 800 -H 480   # custom screen size (tested: Up to 1280x720)
 
 DISP_WIDTH=512
 DISP_HEIGHT=342
@@ -14,7 +15,7 @@ DISC_IMAGE=
 CMAKE_ARGS=""
 OVERCLOCK=0
 
-while getopts "hovd:m:" o; do
+while getopts "hovd:m:W:H:" o; do
     case "$o" in
     (o)
         OVERCLOCK=1
@@ -22,7 +23,12 @@ while getopts "hovd:m:" o; do
     (v)
         DISP_WIDTH=640
         DISP_HEIGHT=480
-        CMAKE_ARGS="-DUSE_VGA_RES=1"
+        ;;
+    (W)
+        DISP_WIDTH=$OPTARG
+        ;;
+    (H)
+        DISP_HEIGHT=$OPTARG
         ;;
     (m)
         MEMSIZE=$OPTARG
@@ -34,9 +40,10 @@ while getopts "hovd:m:" o; do
         echo "Usage: $0 [-v] [-m KiB] [-d diskimage]"
         echo ""
         echo "   -v: Use framebuffer resolution 640x480 instead of 512x342"
+        echo "   -W # -h #: Use specific framebuffer resolution"
         echo "   -m: Set memory size in KiB (over 400kB requires psram)"
         echo "   -d: Specify disc image to include"
-        echo "   -o: Overclock to 264MHz (known to be incompatible with psram)"
+        echo "   -o: Overclock to 264MHz"
         echo ""
         echo "PSRAM is automatically set depending on memory & framebuffer details"
         exit
@@ -56,10 +63,7 @@ if [ $PSRAM -ne 0 ] ; then
     CMAKE_ARGS="$CMAKE_ARGS -DUSE_PSRAM=1"
 fi
 
-MIRROR_FRAMEBUFFER=$((USE_PSRAM || DISP_WIDTH != 640))
-if [ "$MIRROR_FRAMEBUFFER" -eq 0 ]; then
-    CMAKE_ARGS="$CMAKE_ARGS -DHSTX_CKP=12 -DHSTX_D0P=14 -DHSTX_D1P=16 -DHSTX_D2P=18 "
-fi
+MIRROR_FRAMEBUFFER=$((PSRAM || DISP_WIDTH < 640))
 
 # Append disk name to build directory if disk image is specified
 if [ -n "$DISC_IMAGE" ] && [ -f "$DISC_IMAGE" ]; then
@@ -84,7 +88,11 @@ cmake -S . -B build_${TAG} \
     -DSD_TX=35 -DSD_RX=36 -DSD_SCK=34 -DSD_CS=39 -DUSE_SD=1 \
     -DUART_TX=44 -DUART_RX=45 -DUART=0 \
     -DBOARD_FILE=boards/adafruit_fruit_jam.c \
+    -DMIRROR_FRAMEBUFFER=${MIRROR_FRAMEBUFFER} \
+    -DHSTX_CKP=12 -DHSTX_D0P=14 -DHSTX_D1P=16 -DHSTX_D2P=18 \
     -DSD_MHZ=16 \
     -DOVERCLOCK=${OVERCLOCK} \
+    -DDISP_WIDTH=${DISP_WIDTH} \
+    -DDISP_HEIGHT=${DISP_HEIGHT} \
     ${CMAKE_ARGS} "$@"
 make -C build_${TAG} -j$(nproc)

--- a/include/clocking.h
+++ b/include/clocking.h
@@ -8,4 +8,5 @@ enum clk_sys_speed {
     CLK_SYS_132MHZ = 4,
 };
 
-extern void overclock(enum clk_sys_speed clk_sys_div, uint32_t bit_clk_hz);
+extern void overclock(enum clk_sys_speed clk_sys_div);
+void hstx_clock_hz(uint32_t bit_clk_hz);

--- a/include/video.h
+++ b/include/video.h
@@ -28,6 +28,6 @@
 
 #include <inttypes.h>
 
-void    video_init(uint32_t *framebuffer);
+void    video_init(uint32_t *framebuffer, int width, int height, float refresh);
 
 #endif

--- a/src/clocking.c
+++ b/src/clocking.c
@@ -33,7 +33,7 @@ static void __no_inline_not_in_flash_func(set_qmi_timing)() {
 #endif
 
 #ifndef RP2350_PSRAM_RX_DELAY_FS
-#define RP2350_PSRAM_RX_DELAY_FS (3333333)
+#define RP2350_PSRAM_RX_DELAY_FS (3333333*2)
 #endif
 
 #ifndef RP2350_PSRAM_MAX_SCK_HZ
@@ -79,7 +79,7 @@ static void __no_inline_not_in_flash_func(set_psram_timing)(void) {
     qmi_hw->m[1].timing = QMI_M1_TIMING_PAGEBREAK_VALUE_1024 << QMI_M1_TIMING_PAGEBREAK_LSB | // Break between pages.
                           3 << QMI_M1_TIMING_SELECT_HOLD_LSB | // Delay releasing CS for 3 extra system cycles.
                           rxDelay << QMI_M1_TIMING_RXDELAY_LSB | // Delay between SCK and RX sampling
-                          1 << QMI_M1_TIMING_COOLDOWN_LSB | 1 << QMI_M1_TIMING_RXDELAY_LSB |
+                          1 << QMI_M1_TIMING_COOLDOWN_LSB |
                           maxSelect << QMI_M1_TIMING_MAX_SELECT_LSB | minDeselect << QMI_M1_TIMING_MIN_DESELECT_LSB |
                           clockDivider << QMI_M1_TIMING_CLKDIV_LSB;
 
@@ -94,7 +94,8 @@ static void __no_inline_not_in_flash_func(clock_init)(int sys_clk_div) {
     hw_write_masked(&qmi_hw->m[0].timing, 6, QMI_M0_TIMING_CLKDIV_BITS);
 
     // We're going to go fast, boost the voltage a little
-    vreg_set_voltage(VREG_VOLTAGE_1_15);
+    if (sys_clk_div != CLK_SYS_132MHZ) 
+        vreg_set_voltage(VREG_VOLTAGE_1_20);
 
     // Force a read through XIP to ensure the timing is applied before raising the clock rate
     volatile uint32_t* ptr = (volatile uint32_t*)0x14000000;

--- a/src/clocking.c
+++ b/src/clocking.c
@@ -1,6 +1,8 @@
 #include "clocking.h"
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <limits.h>
 #include "pico.h"
 #include "pico/stdio.h"
 #include "hardware/clocks.h"
@@ -113,7 +115,7 @@ static void __no_inline_not_in_flash_func(clock_init)(int sys_clk_div) {
     clock_stop(clk_hstx);
 
     // Set USB PLL to 528MHz
-    pll_init(pll_usb, PLL_COMMON_REFDIV, 1584 * MHZ, 3, 1);
+    pll_init(pll_usb, PLL_USB_REFDIV, 1584 * MHZ, 3, 1);
 
     const uint32_t usb_pll_freq = 528 * MHZ;
 
@@ -149,32 +151,63 @@ static void __no_inline_not_in_flash_func(clock_init)(int sys_clk_div) {
     restore_interrupts(intr_stash);
 }
 
-void overclock(enum clk_sys_speed clk_sys_div, uint32_t bit_clk_khz) {
+void overclock(enum clk_sys_speed clk_sys_div) {
     clock_init(clk_sys_div);
-	stdio_init_all();
+    stdio_init_all();
     set_psram_timing();
 #define SHOW_CLK(i) printf("clk_get_hz(%s) -> %u\n", #i, clock_get_hz(i));
-        SHOW_CLK(clk_ref);
-        SHOW_CLK(clk_sys);
-        SHOW_CLK(clk_peri);
-        SHOW_CLK(clk_hstx);
-        SHOW_CLK(clk_usb);
-        SHOW_CLK(clk_adc);
+    uint f_pll_usb = frequency_count_khz(CLOCKS_FC0_SRC_VALUE_PLL_USB_CLKSRC_PRIMARY);
+    printf("f_pll_usb = %d\n", f_pll_usb);
+    SHOW_CLK(clk_ref);
+    SHOW_CLK(clk_sys);
+    SHOW_CLK(clk_peri);
+    SHOW_CLK(clk_hstx);
+    SHOW_CLK(clk_usb);
+    SHOW_CLK(clk_adc);
+}
 
-
-    const uint32_t dvi_clock_khz = bit_clk_khz >> 1;
-printf("bit_clk_khz = %u dvi_clock_khz = %u\n", bit_clk_khz, dvi_clock_khz);
+static int best_sys_clock_hz(uint32_t freq_hz, uint *vco_out, uint *postdiv1_out, uint *postdiv2_out) {
+    uint reference_freq_hz = XOSC_HZ / PLL_SYS_REFDIV;
+    int best = INT_MAX;
+    int bestfreq = 0;
+    for (uint fbdiv = 320; fbdiv >= 16; fbdiv--) {
+        uint vco_hz = fbdiv * reference_freq_hz;
+        if (vco_hz < PICO_PLL_VCO_MIN_FREQ_HZ || vco_hz > PICO_PLL_VCO_MAX_FREQ_HZ) continue;
+        for (uint postdiv1 = 7; postdiv1 >= 1; postdiv1--) {
+            for (uint postdiv2 = postdiv1; postdiv2 >= 1; postdiv2--) {
+                uint out = vco_hz / (postdiv1 * postdiv2);
+                int diff = abs(freq_hz - out);
+                int absdiff = abs(diff);
+                if (absdiff < best && !(vco_hz % (postdiv1 * postdiv2))) {
+                    printf("out=%d diff=%d absdiff=%d\n", out, diff, absdiff);
+                    best = absdiff;
+                    bestfreq = out;
+                    *vco_out = vco_hz;
+                    *postdiv1_out = postdiv1;
+                    *postdiv2_out = postdiv2;
+                }
+            }
+        }
+    }
+    return bestfreq;
+}
+void hstx_clock_hz(uint32_t bit_clk_hz) {
+    const uint32_t dvi_clock_hz = bit_clk_hz >> 1;
+    printf("bit_clk_hz = %u dvi_clock_hz = %u\n", bit_clk_hz, dvi_clock_hz);
     uint vco_freq, post_div1, post_div2;
-    if (!check_sys_clock_khz(dvi_clock_khz, &vco_freq, &post_div1, &post_div2))
-        panic("System clock of %u kHz cannot be exactly achieved", dvi_clock_khz);
-    const uint32_t freq = vco_freq / (post_div1 * post_div2);
+    int freq = best_sys_clock_hz(dvi_clock_hz, &vco_freq, &post_div1, &post_div2);
+    printf("dvi_clk_hz=%d freq=%d vco_freq=%d/(%d*%d)\n", dvi_clock_hz, freq, vco_freq, post_div1, post_div2);
+    printf("frequency difference of %dHz\n", dvi_clock_hz - freq);
 
     // Set the sys PLL to the requested freq
-    pll_init(pll_sys, PLL_COMMON_REFDIV, vco_freq, post_div1, post_div2);
+    pll_init(pll_sys, PLL_SYS_REFDIV, vco_freq, post_div1, post_div2);
 
     // CLK HSTX = Requested freq
     clock_configure(clk_hstx,
                     0,
                     CLOCKS_CLK_HSTX_CTRL_AUXSRC_VALUE_CLKSRC_PLL_SYS,
                     freq, freq);
+    uint f_pll_sys = frequency_count_khz(CLOCKS_FC0_SRC_VALUE_PLL_SYS_CLKSRC_PRIMARY);
+    printf("f_pll_sys = %d\n", f_pll_sys);
+    SHOW_CLK(clk_hstx);
 }

--- a/src/gtf.c
+++ b/src/gtf.c
@@ -1,0 +1,699 @@
+/* gtf.c  Generate mode timings using the GTF Timing Standard
+ *
+ * gcc gtf.c -o gtf -lm -Wall
+ *
+ * Copyright (c) 2001, Andy Ritger  aritger@nvidia.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * o Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * o Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer
+ *   in the documentation and/or other materials provided with the
+ *   distribution.
+ * o Neither the name of NVIDIA nor the names of its contributors
+ *   may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ *
+ * This program is based on the Generalized Timing Formula(GTF TM)
+ * Standard Version: 1.0, Revision: 1.0
+ *
+ * The GTF Document contains the following Copyright information:
+ *
+ * Copyright (c) 1994, 1995, 1996 - Video Electronics Standards
+ * Association. Duplication of this document within VESA member
+ * companies for review purposes is permitted. All other rights
+ * reserved.
+ *
+ * While every precaution has been taken in the preparation
+ * of this standard, the Video Electronics Standards Association and
+ * its contributors assume no responsibility for errors or omissions,
+ * and make no warranties, expressed or implied, of functionality
+ * of suitability for any purpose. The sample code contained within
+ * this standard may be used without restriction.
+ *
+ *
+ *
+ * The GTF EXCEL(TM) SPREADSHEET, a sample (and the definitive)
+ * implementation of the GTF Timing Standard, is available at:
+ *
+ * ftp://ftp.vesa.org/pub/GTF/GTF_V1R1.xls
+ *
+ *
+ *
+ * This program takes a desired resolution and vertical refresh rate,
+ * and computes mode timings according to the GTF Timing Standard.
+ * These mode timings can then be formatted as an XServer modeline
+ * or a mode description for use by fbset(8).
+ *
+ *
+ *
+ * NOTES:
+ *
+ * The GTF allows for computation of "margins" (the visible border
+ * surrounding the addressable video); on most non-overscan type
+ * systems, the margin period is zero.  I've implemented the margin
+ * computations but not enabled it because 1) I don't really have
+ * any experience with this, and 2) neither XServer modelines nor
+ * fbset fb.modes provide an obvious way for margin timings to be
+ * included in their mode descriptions (needs more investigation).
+ *
+ * The GTF provides for computation of interlaced mode timings;
+ * I've implemented the computations but not enabled them, yet.
+ * I should probably enable and test this at some point.
+ *
+ *
+ *
+ * TODO:
+ *
+ * o Add support for interlaced modes.
+ *
+ * o Implement the other portions of the GTF: compute mode timings
+ *   given either the desired pixel clock or the desired horizontal
+ *   frequency.
+ *
+ * o It would be nice if this were more general purpose to do things
+ *   outside the scope of the GTF: like generate double scan mode
+ *   timings, for example.
+ *
+ * o Printing digits to the right of the decimal point when the
+ *   digits are 0 annoys me.
+ *
+ * o Error checking.
+ *
+ */
+
+#ifdef HAVE_XORG_CONFIG_H
+#include <xorg-config.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#define MARGIN_PERCENT    1.8   /* % of active vertical image                */
+#define CELL_GRAN         8.0   /* assumed character cell granularity        */
+#define MIN_PORCH         1     /* minimum front porch                       */
+#define V_SYNC_RQD        3     /* width of vsync in lines                   */
+#define H_SYNC_PERCENT    8.0   /* width of hsync as % of total line         */
+#define MIN_VSYNC_PLUS_BP 550.0 /* min time of vsync + back porch (microsec) */
+#define M                 600.0 /* blanking formula gradient                 */
+#define C                 40.0  /* blanking formula offset                   */
+#define K                 128.0 /* blanking formula scaling factor           */
+#define J                 20.0  /* blanking formula scaling factor           */
+
+/* C' and M' are part of the Blanking Duty Cycle computation */
+
+#define C_PRIME           (((C - J) * K/256.0) + J)
+#define M_PRIME           (K/256.0 * M)
+
+/* struct definitions */
+
+typedef struct __mode {
+    int hr, hss, hse, hfl;
+    int vr, vss, vse, vfl;
+    float pclk, h_freq, v_freq;
+} mode;
+
+typedef struct __options {
+    int x, y;
+    int xorgmode, fbmode;
+    float v_freq;
+} options;
+
+/* prototypes */
+
+void print_value(int n, const char *name, float val);
+void print_xf86_mode(mode * m);
+void print_fb_mode(mode * m);
+mode *vert_refresh(int h_pixels, int v_lines, float freq,
+                   int interlaced, int margins);
+options *parse_command_line(int argc, char *argv[]);
+
+/*
+ * print_value() - print the result of the named computation; this is
+ * useful when comparing against the GTF EXCEL spreadsheet.
+ */
+
+int global_verbose = 0;
+
+void
+print_value(int n, const char *name, float val)
+{
+    if (global_verbose) {
+        printf("%2d: %-27s: %15f\n", n, name, val);
+    }
+}
+
+/* print_xf86_mode() - print the XServer modeline, given mode timings. */
+
+void
+print_xf86_mode(mode * m)
+{
+    printf("\n");
+    printf("  # %dx%d @ %.2f Hz (GTF) hsync: %.2f kHz; pclk: %.2f MHz\n",
+           m->hr, m->vr, m->v_freq, m->h_freq, m->pclk);
+
+    printf("  Modeline \"%dx%d_%.2f\"  %.2f"
+           "  %d %d %d %d"
+           "  %d %d %d %d"
+           "  -HSync +Vsync\n\n",
+           m->hr, m->vr, m->v_freq, m->pclk,
+           m->hr, m->hss, m->hse, m->hfl, m->vr, m->vss, m->vse, m->vfl);
+
+}
+
+/*
+ * print_fb_mode() - print a mode description in fbset(8) format;
+ * see the fb.modes(8) manpage.  The timing description used in
+ * this is rather odd; they use "left and right margin" to refer
+ * to the portion of the hblank before and after the sync pulse
+ * by conceptually wrapping the portion of the blank after the pulse
+ * to infront of the visible region; ie:
+ *
+ *
+ * Timing description I'm accustomed to:
+ *
+ *
+ *
+ *     <--------1--------> <--2--> <--3--> <--4-->
+ *                                _________
+ *    |-------------------|_______|       |_______
+ *
+ *                        R       SS      SE     FL
+ *
+ * 1: visible image
+ * 2: blank before sync (aka front porch)
+ * 3: sync pulse
+ * 4: blank after sync (aka back porch)
+ * R: Resolution
+ * SS: Sync Start
+ * SE: Sync End
+ * FL: Frame Length
+ *
+ *
+ * But the fb.modes format is:
+ *
+ *
+ *    <--4--> <--------1--------> <--2--> <--3-->
+ *                                       _________
+ *    _______|-------------------|_______|       |
+ *
+ * The fb.modes(8) manpage refers to <4> and <2> as the left and
+ * right "margin" (as well as upper and lower margin in the vertical
+ * direction) -- note that this has nothing to do with the term
+ * "margin" used in the GTF Timing Standard.
+ *
+ * XXX always prints the 32 bit mode -- should I provide a command
+ * line option to specify the bpp?  It's simple enough for a user
+ * to edit the mode description after it's generated.
+ */
+
+void
+print_fb_mode(mode * m)
+{
+    printf("\n");
+    printf("mode \"%dx%d %.2fHz 32bit (GTF)\"\n", m->hr, m->vr, m->v_freq);
+    printf("    # PCLK: %.2f MHz, H: %.2f kHz, V: %.2f Hz\n",
+           m->pclk, m->h_freq, m->v_freq);
+    printf("    geometry %d %d %d %d 32\n", m->hr, m->vr, m->hr, m->vr);
+    printf("    timings %d %d %d %d %d %d %d\n", (int)lrint(1000000.0 / m->pclk),       /* pixclock in picoseconds */
+           m->hfl - m->hse,     /* left margin (in pixels) */
+           m->hss - m->hr,      /* right margin (in pixels) */
+           m->vfl - m->vse,     /* upper margin (in pixel lines) */
+           m->vss - m->vr,      /* lower margin (in pixel lines) */
+           m->hse - m->hss,     /* horizontal sync length (pixels) */
+           m->vse - m->vss);    /* vert sync length (pixel lines) */
+    printf("    hsync low\n");
+    printf("    vsync high\n");
+    printf("endmode\n\n");
+
+}
+
+/*
+ * vert_refresh() - as defined by the GTF Timing Standard, compute the
+ * Stage 1 Parameters using the vertical refresh frequency.  In other
+ * words: input a desired resolution and desired refresh rate, and
+ * output the GTF mode timings.
+ *
+ * XXX All the code is in place to compute interlaced modes, but I don't
+ * feel like testing it right now.
+ *
+ * XXX margin computations are implemented but not tested (nor used by
+ * XServer of fbset mode descriptions, from what I can tell).
+ */
+
+mode *
+vert_refresh(int h_pixels, int v_lines, float freq, int interlaced, int margins)
+{
+    float h_pixels_rnd;
+    float v_lines_rnd;
+    float v_field_rate_rqd;
+    float top_margin;
+    float bottom_margin;
+    float interlace;
+    float h_period_est;
+    float vsync_plus_bp;
+    float v_back_porch;
+    float total_v_lines;
+    float v_field_rate_est;
+    float h_period;
+    float v_field_rate;
+    float v_frame_rate;
+    float left_margin;
+    float right_margin;
+    float total_active_pixels;
+    float ideal_duty_cycle;
+    float h_blank;
+    float total_pixels;
+    float pixel_freq;
+    float h_freq;
+
+    float h_sync;
+    float h_front_porch;
+    float v_odd_front_porch_lines;
+
+    mode *m = (mode *) malloc(sizeof(mode));
+
+    /*  1. In order to give correct results, the number of horizontal
+     *  pixels requested is first processed to ensure that it is divisible
+     *  by the character size, by rounding it to the nearest character
+     *  cell boundary:
+     *
+     *  [H PIXELS RND] = ((ROUND([H PIXELS]/[CELL GRAN RND],0))*[CELLGRAN RND])
+     */
+
+    h_pixels_rnd = rint((float) h_pixels / CELL_GRAN) * CELL_GRAN;
+
+    print_value(1, "[H PIXELS RND]", h_pixels_rnd);
+
+    /*  2. If interlace is requested, the number of vertical lines assumed
+     *  by the calculation must be halved, as the computation calculates
+     *  the number of vertical lines per field. In either case, the
+     *  number of lines is rounded to the nearest integer.
+     *
+     *  [V LINES RND] = IF([INT RQD?]="y", ROUND([V LINES]/2,0),
+     *                                     ROUND([V LINES],0))
+     */
+
+    v_lines_rnd = interlaced ?
+        rint((float) v_lines) / 2.0 : rint((float) v_lines);
+
+    print_value(2, "[V LINES RND]", v_lines_rnd);
+
+    /*  3. Find the frame rate required:
+     *
+     *  [V FIELD RATE RQD] = IF([INT RQD?]="y", [I/P FREQ RQD]*2,
+     *                                          [I/P FREQ RQD])
+     */
+
+    v_field_rate_rqd = interlaced ? (freq * 2.0) : (freq);
+
+    print_value(3, "[V FIELD RATE RQD]", v_field_rate_rqd);
+
+    /*  4. Find number of lines in Top margin:
+     *
+     *  [TOP MARGIN (LINES)] = IF([MARGINS RQD?]="Y",
+     *          ROUND(([MARGIN%]/100*[V LINES RND]),0),
+     *          0)
+     */
+
+    top_margin = margins ? rint(MARGIN_PERCENT / 100.0 * v_lines_rnd) : (0.0);
+
+    print_value(4, "[TOP MARGIN (LINES)]", top_margin);
+
+    /*  5. Find number of lines in Bottom margin:
+     *
+     *  [BOT MARGIN (LINES)] = IF([MARGINS RQD?]="Y",
+     *          ROUND(([MARGIN%]/100*[V LINES RND]),0),
+     *          0)
+     */
+
+    bottom_margin =
+        margins ? rint(MARGIN_PERCENT / 100.0 * v_lines_rnd) : (0.0);
+
+    print_value(5, "[BOT MARGIN (LINES)]", bottom_margin);
+
+    /*  6. If interlace is required, then set variable [INTERLACE]=0.5:
+     *
+     *  [INTERLACE]=(IF([INT RQD?]="y",0.5,0))
+     */
+
+    interlace = interlaced ? 0.5 : 0.0;
+
+    print_value(6, "[INTERLACE]", interlace);
+
+    /*  7. Estimate the Horizontal period
+     *
+     *  [H PERIOD EST] = ((1/[V FIELD RATE RQD]) - [MIN VSYNC+BP]/1000000) /
+     *                    ([V LINES RND] + (2*[TOP MARGIN (LINES)]) +
+     *                     [MIN PORCH RND]+[INTERLACE]) * 1000000
+     */
+
+    h_period_est = (((1.0 / v_field_rate_rqd) - (MIN_VSYNC_PLUS_BP / 1000000.0))
+                    / (v_lines_rnd + (2 * top_margin) + MIN_PORCH + interlace)
+                    * 1000000.0);
+
+    print_value(7, "[H PERIOD EST]", h_period_est);
+
+    /*  8. Find the number of lines in V sync + back porch:
+     *
+     *  [V SYNC+BP] = ROUND(([MIN VSYNC+BP]/[H PERIOD EST]),0)
+     */
+
+    vsync_plus_bp = rint(MIN_VSYNC_PLUS_BP / h_period_est);
+
+    print_value(8, "[V SYNC+BP]", vsync_plus_bp);
+
+    /*  9. Find the number of lines in V back porch alone:
+     *
+     *  [V BACK PORCH] = [V SYNC+BP] - [V SYNC RND]
+     *
+     *  XXX is "[V SYNC RND]" a typo? should be [V SYNC RQD]?
+     */
+
+    v_back_porch = vsync_plus_bp - V_SYNC_RQD;
+
+    print_value(9, "[V BACK PORCH]", v_back_porch);
+
+    /*  10. Find the total number of lines in Vertical field period:
+     *
+     *  [TOTAL V LINES] = [V LINES RND] + [TOP MARGIN (LINES)] +
+     *                    [BOT MARGIN (LINES)] + [V SYNC+BP] + [INTERLACE] +
+     *                    [MIN PORCH RND]
+     */
+
+    total_v_lines = v_lines_rnd + top_margin + bottom_margin + vsync_plus_bp +
+        interlace + MIN_PORCH;
+
+    print_value(10, "[TOTAL V LINES]", total_v_lines);
+
+    /*  11. Estimate the Vertical field frequency:
+     *
+     *  [V FIELD RATE EST] = 1 / [H PERIOD EST] / [TOTAL V LINES] * 1000000
+     */
+
+    v_field_rate_est = 1.0 / h_period_est / total_v_lines * 1000000.0;
+
+    print_value(11, "[V FIELD RATE EST]", v_field_rate_est);
+
+    /*  12. Find the actual horizontal period:
+     *
+     *  [H PERIOD] = [H PERIOD EST] / ([V FIELD RATE RQD] / [V FIELD RATE EST])
+     */
+
+    h_period = h_period_est / (v_field_rate_rqd / v_field_rate_est);
+
+    print_value(12, "[H PERIOD]", h_period);
+
+    /*  13. Find the actual Vertical field frequency:
+     *
+     *  [V FIELD RATE] = 1 / [H PERIOD] / [TOTAL V LINES] * 1000000
+     */
+
+    v_field_rate = 1.0 / h_period / total_v_lines * 1000000.0;
+
+    print_value(13, "[V FIELD RATE]", v_field_rate);
+
+    /*  14. Find the Vertical frame frequency:
+     *
+     *  [V FRAME RATE] = (IF([INT RQD?]="y", [V FIELD RATE]/2, [V FIELD RATE]))
+     */
+
+    v_frame_rate = interlaced ? v_field_rate / 2.0 : v_field_rate;
+
+    print_value(14, "[V FRAME RATE]", v_frame_rate);
+
+    /*  15. Find number of pixels in left margin:
+     *
+     *  [LEFT MARGIN (PIXELS)] = (IF( [MARGINS RQD?]="Y",
+     *          (ROUND( ([H PIXELS RND] * [MARGIN%] / 100 /
+     *                   [CELL GRAN RND]),0)) * [CELL GRAN RND],
+     *          0))
+     */
+
+    left_margin = margins ?
+        rint(h_pixels_rnd * MARGIN_PERCENT / 100.0 / CELL_GRAN) * CELL_GRAN :
+        0.0;
+
+    print_value(15, "[LEFT MARGIN (PIXELS)]", left_margin);
+
+    /*  16. Find number of pixels in right margin:
+     *
+     *  [RIGHT MARGIN (PIXELS)] = (IF( [MARGINS RQD?]="Y",
+     *          (ROUND( ([H PIXELS RND] * [MARGIN%] / 100 /
+     *                   [CELL GRAN RND]),0)) * [CELL GRAN RND],
+     *          0))
+     */
+
+    right_margin = margins ?
+        rint(h_pixels_rnd * MARGIN_PERCENT / 100.0 / CELL_GRAN) * CELL_GRAN :
+        0.0;
+
+    print_value(16, "[RIGHT MARGIN (PIXELS)]", right_margin);
+
+    /*  17. Find total number of active pixels in image and left and right
+     *  margins:
+     *
+     *  [TOTAL ACTIVE PIXELS] = [H PIXELS RND] + [LEFT MARGIN (PIXELS)] +
+     *                          [RIGHT MARGIN (PIXELS)]
+     */
+
+    total_active_pixels = h_pixels_rnd + left_margin + right_margin;
+
+    print_value(17, "[TOTAL ACTIVE PIXELS]", total_active_pixels);
+
+    /*  18. Find the ideal blanking duty cycle from the blanking duty cycle
+     *  equation:
+     *
+     *  [IDEAL DUTY CYCLE] = [C'] - ([M']*[H PERIOD]/1000)
+     */
+
+    ideal_duty_cycle = C_PRIME - (M_PRIME * h_period / 1000.0);
+
+    print_value(18, "[IDEAL DUTY CYCLE]", ideal_duty_cycle);
+
+    /*  19. Find the number of pixels in the blanking time to the nearest
+     *  double character cell:
+     *
+     *  [H BLANK (PIXELS)] = (ROUND(([TOTAL ACTIVE PIXELS] *
+     *                               [IDEAL DUTY CYCLE] /
+     *                               (100-[IDEAL DUTY CYCLE]) /
+     *                               (2*[CELL GRAN RND])), 0))
+     *                       * (2*[CELL GRAN RND])
+     */
+
+    h_blank = rint(total_active_pixels *
+                   ideal_duty_cycle /
+                   (100.0 - ideal_duty_cycle) /
+                   (2.0 * CELL_GRAN)) * (2.0 * CELL_GRAN);
+
+    print_value(19, "[H BLANK (PIXELS)]", h_blank);
+
+    /*  20. Find total number of pixels:
+     *
+     *  [TOTAL PIXELS] = [TOTAL ACTIVE PIXELS] + [H BLANK (PIXELS)]
+     */
+
+    total_pixels = total_active_pixels + h_blank;
+
+    print_value(20, "[TOTAL PIXELS]", total_pixels);
+
+    /*  21. Find pixel clock frequency:
+     *
+     *  [PIXEL FREQ] = [TOTAL PIXELS] / [H PERIOD]
+     */
+
+    pixel_freq = total_pixels / h_period;
+
+    print_value(21, "[PIXEL FREQ]", pixel_freq);
+
+    /*  22. Find horizontal frequency:
+     *
+     *  [H FREQ] = 1000 / [H PERIOD]
+     */
+
+    h_freq = 1000.0 / h_period;
+
+    print_value(22, "[H FREQ]", h_freq);
+
+    /* Stage 1 computations are now complete; I should really pass
+       the results to another function and do the Stage 2
+       computations, but I only need a few more values so I'll just
+       append the computations here for now */
+
+    /*  17. Find the number of pixels in the horizontal sync period:
+     *
+     *  [H SYNC (PIXELS)] =(ROUND(([H SYNC%] / 100 * [TOTAL PIXELS] /
+     *                             [CELL GRAN RND]),0))*[CELL GRAN RND]
+     */
+
+    h_sync =
+        rint(H_SYNC_PERCENT / 100.0 * total_pixels / CELL_GRAN) * CELL_GRAN;
+
+    print_value(17, "[H SYNC (PIXELS)]", h_sync);
+
+    /*  18. Find the number of pixels in the horizontal front porch period:
+     *
+     *  [H FRONT PORCH (PIXELS)] = ([H BLANK (PIXELS)]/2)-[H SYNC (PIXELS)]
+     */
+
+    h_front_porch = (h_blank / 2.0) - h_sync;
+
+    print_value(18, "[H FRONT PORCH (PIXELS)]", h_front_porch);
+
+    /*  36. Find the number of lines in the odd front porch period:
+     *
+     *  [V ODD FRONT PORCH(LINES)]=([MIN PORCH RND]+[INTERLACE])
+     */
+
+    v_odd_front_porch_lines = MIN_PORCH + interlace;
+
+    print_value(36, "[V ODD FRONT PORCH(LINES)]", v_odd_front_porch_lines);
+
+    /* finally, pack the results in the mode struct */
+
+    m->hr = (int) (h_pixels_rnd);
+    m->hss = (int) (h_pixels_rnd + h_front_porch);
+    m->hse = (int) (h_pixels_rnd + h_front_porch + h_sync);
+    m->hfl = (int) (total_pixels);
+
+    m->vr = (int) (v_lines_rnd);
+    m->vss = (int) (v_lines_rnd + v_odd_front_porch_lines);
+    m->vse = (int) (int) (v_lines_rnd + v_odd_front_porch_lines + V_SYNC_RQD);
+    m->vfl = (int) (total_v_lines);
+
+    m->pclk = pixel_freq;
+    m->h_freq = h_freq;
+    m->v_freq = freq;
+
+    return m;
+
+}
+
+/*
+ * parse_command_line() - parse the command line and return an
+ * alloced structure containing the results.  On error print usage
+ * and return NULL.
+ */
+
+options *
+parse_command_line(int argc, char *argv[])
+{
+    int n;
+
+    options *o = (options *) calloc(1, sizeof(options));
+
+    if (argc < 4)
+        goto bad_option;
+
+    o->x = atoi(argv[1]);
+    o->y = atoi(argv[2]);
+    o->v_freq = atof(argv[3]);
+
+    /* XXX should check for errors in the above */
+
+    n = 4;
+
+    while (n < argc) {
+        if ((strcmp(argv[n], "-v") == 0) || (strcmp(argv[n], "--verbose") == 0)) {
+            global_verbose = 1;
+        }
+        else if ((strcmp(argv[n], "-f") == 0) ||
+                 (strcmp(argv[n], "--fbmode") == 0)) {
+            o->fbmode = 1;
+        }
+        else if ((strcmp(argv[n], "-x") == 0) ||
+                 (strcmp(argv[n], "--xorgmode") == 0) ||
+                 (strcmp(argv[n], "--xf86mode") == 0)) {
+            o->xorgmode = 1;
+        }
+        else {
+            goto bad_option;
+        }
+
+        n++;
+    }
+
+    /* if neither xorgmode nor fbmode were requested, default to
+       xorgmode */
+
+    if (!o->fbmode && !o->xorgmode)
+        o->xorgmode = 1;
+
+    return o;
+
+ bad_option:
+
+    fprintf(stderr, "\n");
+    fprintf(stderr, "usage: %s x y refresh [-v|--verbose] "
+            "[-f|--fbmode] [-x|--xorgmode]\n", argv[0]);
+
+    fprintf(stderr, "\n");
+
+    fprintf(stderr, "            x : the desired horizontal "
+            "resolution (required)\n");
+    fprintf(stderr, "            y : the desired vertical "
+            "resolution (required)\n");
+    fprintf(stderr, "      refresh : the desired refresh " "rate (required)\n");
+    fprintf(stderr, " -v|--verbose : enable verbose printouts "
+            "(traces each step of the computation)\n");
+    fprintf(stderr, "  -f|--fbmode : output an fbset(8)-style mode "
+            "description\n");
+    fprintf(stderr, " -x|--xorgmode : output an " __XSERVERNAME__ "-style mode "
+            "description (this is the default\n"
+            "                if no mode description is requested)\n");
+
+    fprintf(stderr, "\n");
+
+    free(o);
+    return NULL;
+
+}
+
+int
+main(int argc, char *argv[])
+{
+    mode *m;
+    options *o;
+
+    o = parse_command_line(argc, argv);
+    if (!o)
+        exit(1);
+
+    m = vert_refresh(o->x, o->y, o->v_freq, 0, 0);
+    if (!m)
+        exit(1);
+
+    if (o->xorgmode)
+        print_xf86_mode(m);
+
+    if (o->fbmode)
+        print_fb_mode(m);
+
+    free(m);
+
+    return 0;
+
+}

--- a/src/gtf.c
+++ b/src/gtf.c
@@ -1,7 +1,5 @@
 /* gtf.c  Generate mode timings using the GTF Timing Standard
  *
- * gcc gtf.c -o gtf -lm -Wall
- *
  * Copyright (c) 2001, Andy Ritger  aritger@nvidia.com
  * All rights reserved.
  *
@@ -103,14 +101,12 @@
  *
  */
 
-#ifdef HAVE_XORG_CONFIG_H
-#include <xorg-config.h>
-#endif
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+
+#include "gtf.h"
 
 #define MARGIN_PERCENT    1.8   /* % of active vertical image                */
 #define CELL_GRAN         8.0   /* assumed character cell granularity        */
@@ -130,33 +126,16 @@
 
 /* struct definitions */
 
-typedef struct __mode {
-    int hr, hss, hse, hfl;
-    int vr, vss, vse, vfl;
-    float pclk, h_freq, v_freq;
-} mode;
-
-typedef struct __options {
-    int x, y;
-    int xorgmode, fbmode;
-    float v_freq;
-} options;
-
 /* prototypes */
 
 void print_value(int n, const char *name, float val);
-void print_xf86_mode(mode * m);
-void print_fb_mode(mode * m);
-mode *vert_refresh(int h_pixels, int v_lines, float freq,
-                   int interlaced, int margins);
-options *parse_command_line(int argc, char *argv[]);
 
 /*
  * print_value() - print the result of the named computation; this is
  * useful when comparing against the GTF EXCEL spreadsheet.
  */
 
-int global_verbose = 0;
+const int global_verbose = 1;
 
 void
 print_value(int n, const char *name, float val)
@@ -164,91 +143,6 @@ print_value(int n, const char *name, float val)
     if (global_verbose) {
         printf("%2d: %-27s: %15f\n", n, name, val);
     }
-}
-
-/* print_xf86_mode() - print the XServer modeline, given mode timings. */
-
-void
-print_xf86_mode(mode * m)
-{
-    printf("\n");
-    printf("  # %dx%d @ %.2f Hz (GTF) hsync: %.2f kHz; pclk: %.2f MHz\n",
-           m->hr, m->vr, m->v_freq, m->h_freq, m->pclk);
-
-    printf("  Modeline \"%dx%d_%.2f\"  %.2f"
-           "  %d %d %d %d"
-           "  %d %d %d %d"
-           "  -HSync +Vsync\n\n",
-           m->hr, m->vr, m->v_freq, m->pclk,
-           m->hr, m->hss, m->hse, m->hfl, m->vr, m->vss, m->vse, m->vfl);
-
-}
-
-/*
- * print_fb_mode() - print a mode description in fbset(8) format;
- * see the fb.modes(8) manpage.  The timing description used in
- * this is rather odd; they use "left and right margin" to refer
- * to the portion of the hblank before and after the sync pulse
- * by conceptually wrapping the portion of the blank after the pulse
- * to infront of the visible region; ie:
- *
- *
- * Timing description I'm accustomed to:
- *
- *
- *
- *     <--------1--------> <--2--> <--3--> <--4-->
- *                                _________
- *    |-------------------|_______|       |_______
- *
- *                        R       SS      SE     FL
- *
- * 1: visible image
- * 2: blank before sync (aka front porch)
- * 3: sync pulse
- * 4: blank after sync (aka back porch)
- * R: Resolution
- * SS: Sync Start
- * SE: Sync End
- * FL: Frame Length
- *
- *
- * But the fb.modes format is:
- *
- *
- *    <--4--> <--------1--------> <--2--> <--3-->
- *                                       _________
- *    _______|-------------------|_______|       |
- *
- * The fb.modes(8) manpage refers to <4> and <2> as the left and
- * right "margin" (as well as upper and lower margin in the vertical
- * direction) -- note that this has nothing to do with the term
- * "margin" used in the GTF Timing Standard.
- *
- * XXX always prints the 32 bit mode -- should I provide a command
- * line option to specify the bpp?  It's simple enough for a user
- * to edit the mode description after it's generated.
- */
-
-void
-print_fb_mode(mode * m)
-{
-    printf("\n");
-    printf("mode \"%dx%d %.2fHz 32bit (GTF)\"\n", m->hr, m->vr, m->v_freq);
-    printf("    # PCLK: %.2f MHz, H: %.2f kHz, V: %.2f Hz\n",
-           m->pclk, m->h_freq, m->v_freq);
-    printf("    geometry %d %d %d %d 32\n", m->hr, m->vr, m->hr, m->vr);
-    printf("    timings %d %d %d %d %d %d %d\n", (int)lrint(1000000.0 / m->pclk),       /* pixclock in picoseconds */
-           m->hfl - m->hse,     /* left margin (in pixels) */
-           m->hss - m->hr,      /* right margin (in pixels) */
-           m->vfl - m->vse,     /* upper margin (in pixel lines) */
-           m->vss - m->vr,      /* lower margin (in pixel lines) */
-           m->hse - m->hss,     /* horizontal sync length (pixels) */
-           m->vse - m->vss);    /* vert sync length (pixel lines) */
-    printf("    hsync low\n");
-    printf("    vsync high\n");
-    printf("endmode\n\n");
-
 }
 
 /*
@@ -264,8 +158,8 @@ print_fb_mode(mode * m)
  * XServer of fbset mode descriptions, from what I can tell).
  */
 
-mode *
-vert_refresh(int h_pixels, int v_lines, float freq, int interlaced, int margins)
+gtf_mode_t *
+gtf_calculate(gtf_mode_t *m, int h_pixels, int v_lines, float freq)
 {
     float h_pixels_rnd;
     float v_lines_rnd;
@@ -294,7 +188,8 @@ vert_refresh(int h_pixels, int v_lines, float freq, int interlaced, int margins)
     float h_front_porch;
     float v_odd_front_porch_lines;
 
-    mode *m = (mode *) malloc(sizeof(mode));
+    const int interlaced = 0;
+    const int margins = 0;
 
     /*  1. In order to give correct results, the number of horizontal
      *  pixels requested is first processed to ensure that it is divisible
@@ -317,8 +212,7 @@ vert_refresh(int h_pixels, int v_lines, float freq, int interlaced, int margins)
      *                                     ROUND([V LINES],0))
      */
 
-    v_lines_rnd = interlaced ?
-        rint((float) v_lines) / 2.0 : rint((float) v_lines);
+    v_lines_rnd = interlaced ? rint((float) v_lines) / 2.0 : rint((float) v_lines);
 
     print_value(2, "[V LINES RND]", v_lines_rnd);
 
@@ -589,111 +483,5 @@ vert_refresh(int h_pixels, int v_lines, float freq, int interlaced, int margins)
     m->v_freq = freq;
 
     return m;
-
-}
-
-/*
- * parse_command_line() - parse the command line and return an
- * alloced structure containing the results.  On error print usage
- * and return NULL.
- */
-
-options *
-parse_command_line(int argc, char *argv[])
-{
-    int n;
-
-    options *o = (options *) calloc(1, sizeof(options));
-
-    if (argc < 4)
-        goto bad_option;
-
-    o->x = atoi(argv[1]);
-    o->y = atoi(argv[2]);
-    o->v_freq = atof(argv[3]);
-
-    /* XXX should check for errors in the above */
-
-    n = 4;
-
-    while (n < argc) {
-        if ((strcmp(argv[n], "-v") == 0) || (strcmp(argv[n], "--verbose") == 0)) {
-            global_verbose = 1;
-        }
-        else if ((strcmp(argv[n], "-f") == 0) ||
-                 (strcmp(argv[n], "--fbmode") == 0)) {
-            o->fbmode = 1;
-        }
-        else if ((strcmp(argv[n], "-x") == 0) ||
-                 (strcmp(argv[n], "--xorgmode") == 0) ||
-                 (strcmp(argv[n], "--xf86mode") == 0)) {
-            o->xorgmode = 1;
-        }
-        else {
-            goto bad_option;
-        }
-
-        n++;
-    }
-
-    /* if neither xorgmode nor fbmode were requested, default to
-       xorgmode */
-
-    if (!o->fbmode && !o->xorgmode)
-        o->xorgmode = 1;
-
-    return o;
-
- bad_option:
-
-    fprintf(stderr, "\n");
-    fprintf(stderr, "usage: %s x y refresh [-v|--verbose] "
-            "[-f|--fbmode] [-x|--xorgmode]\n", argv[0]);
-
-    fprintf(stderr, "\n");
-
-    fprintf(stderr, "            x : the desired horizontal "
-            "resolution (required)\n");
-    fprintf(stderr, "            y : the desired vertical "
-            "resolution (required)\n");
-    fprintf(stderr, "      refresh : the desired refresh " "rate (required)\n");
-    fprintf(stderr, " -v|--verbose : enable verbose printouts "
-            "(traces each step of the computation)\n");
-    fprintf(stderr, "  -f|--fbmode : output an fbset(8)-style mode "
-            "description\n");
-    fprintf(stderr, " -x|--xorgmode : output an " __XSERVERNAME__ "-style mode "
-            "description (this is the default\n"
-            "                if no mode description is requested)\n");
-
-    fprintf(stderr, "\n");
-
-    free(o);
-    return NULL;
-
-}
-
-int
-main(int argc, char *argv[])
-{
-    mode *m;
-    options *o;
-
-    o = parse_command_line(argc, argv);
-    if (!o)
-        exit(1);
-
-    m = vert_refresh(o->x, o->y, o->v_freq, 0, 0);
-    if (!m)
-        exit(1);
-
-    if (o->xorgmode)
-        print_xf86_mode(m);
-
-    if (o->fbmode)
-        print_fb_mode(m);
-
-    free(m);
-
-    return 0;
 
 }

--- a/src/gtf.h
+++ b/src/gtf.h
@@ -1,0 +1,120 @@
+/* gtf.h  Generate mode timings using the GTF Timing Standard
+ *
+ * Copyright (c) 2001, Andy Ritger  aritger@nvidia.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * o Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * o Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer
+ *   in the documentation and/or other materials provided with the
+ *   distribution.
+ * o Neither the name of NVIDIA nor the names of its contributors
+ *   may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ *
+ * This program is based on the Generalized Timing Formula(GTF TM)
+ * Standard Version: 1.0, Revision: 1.0
+ *
+ * The GTF Document contains the following Copyright information:
+ *
+ * Copyright (c) 1994, 1995, 1996 - Video Electronics Standards
+ * Association. Duplication of this document within VESA member
+ * companies for review purposes is permitted. All other rights
+ * reserved.
+ *
+ * While every precaution has been taken in the preparation
+ * of this standard, the Video Electronics Standards Association and
+ * its contributors assume no responsibility for errors or omissions,
+ * and make no warranties, expressed or implied, of functionality
+ * of suitability for any purpose. The sample code contained within
+ * this standard may be used without restriction.
+ *
+ *
+ *
+ * The GTF EXCEL(TM) SPREADSHEET, a sample (and the definitive)
+ * implementation of the GTF Timing Standard, is available at:
+ *
+ * ftp://ftp.vesa.org/pub/GTF/GTF_V1R1.xls
+ *
+ *
+ *
+ * This program takes a desired resolution and vertical refresh rate,
+ * and computes mode timings according to the GTF Timing Standard.
+ * These mode timings can then be formatted as an XServer modeline
+ * or a mode description for use by fbset(8).
+ *
+ *
+ *
+ * NOTES:
+ *
+ * The GTF allows for computation of "margins" (the visible border
+ * surrounding the addressable video); on most non-overscan type
+ * systems, the margin period is zero.  I've implemented the margin
+ * computations but not enabled it because 1) I don't really have
+ * any experience with this, and 2) neither XServer modelines nor
+ * fbset fb.modes provide an obvious way for margin timings to be
+ * included in their mode descriptions (needs more investigation).
+ *
+ * The GTF provides for computation of interlaced mode timings;
+ * I've implemented the computations but not enabled them, yet.
+ * I should probably enable and test this at some point.
+ *
+ *
+ *
+ * TODO:
+ *
+ * o Add support for interlaced modes.
+ *
+ * o Implement the other portions of the GTF: compute mode timings
+ *   given either the desired pixel clock or the desired horizontal
+ *   frequency.
+ *
+ * o It would be nice if this were more general purpose to do things
+ *   outside the scope of the GTF: like generate double scan mode
+ *   timings, for example.
+ *
+ * o Printing digits to the right of the decimal point when the
+ *   digits are 0 annoys me.
+ *
+ * o Error checking.
+ *
+ */
+
+#pragma once
+/*
+ *     <--------1--------> <--2--> <--3--> <--4-->
+ *                                _________
+ *    |-------------------|_______|       |_______
+ *
+ *                        R       SS      SE     FL
+ */
+
+typedef struct gtf_mode {
+    int hr, hss, hse, hfl;
+    int vr, vss, vse, vfl;
+    float pclk, h_freq, v_freq;
+} gtf_mode_t;
+
+gtf_mode_t *
+gtf_calculate(gtf_mode_t *m, int h_pixels, int v_lines, float freq);

--- a/src/main.c
+++ b/src/main.c
@@ -320,9 +320,9 @@ static void     core1_main()
          * core 0's USB activity.
          */
 #if MIRROR_FRAMEBUFFER
-        video_init((uint32_t *)(umac_framebuffer_mirror));
+        video_init((uint32_t *)(umac_framebuffer_mirror), 640, 480, 60);
 #else
-        video_init((uint32_t *)(umac_ram + umac_get_fb_offset()));
+        video_init((uint32_t *)(umac_ram + umac_get_fb_offset()), 640, 480, 60);
 #endif
 
 #if ENABLE_AUDIO
@@ -493,7 +493,9 @@ int     main()
 {
         setup_psram();
 #if OVERCLOCK
-        overclock(CLK_SYS_264MHZ, 252000);
+        overclock(CLK_SYS_264MHZ);
+#else
+        overclock(CLK_SYS_132MHZ);
 #endif
 	stdio_init_all();
 

--- a/src/main.c
+++ b/src/main.c
@@ -87,13 +87,22 @@ static const uint8_t umac_rom[] = {
 
 #if USE_PSRAM
 #define umac_ram ((uint8_t*)0x11000000)
+#define umac_ram_uncached ((uint8_t*)0x15000000)
 #else
 static uint8_t umac_ram[RAM_SIZE];
+#define umac_ram_uncached (umac_ram)
 #endif
 
-#define MIRROR_FRAMEBUFFER (USE_PSRAM || DISP_WIDTH != 640)
 #if MIRROR_FRAMEBUFFER
+#if DISP_WIDTH < 640
 static uint32_t umac_framebuffer_mirror[640*480/32];
+#else
+static uint32_t umac_framebuffer_mirror[DISP_WIDTH*DISP_HEIGHT/32];
+#endif
+#else
+#if DISP_WIDTH < 640
+#error "Mirror required for DISP_WIDTH below 640 (e.g., 512x342)"
+#endif
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -122,12 +131,7 @@ static int umac_cursor_button = 0;
 #if MIRROR_FRAMEBUFFER
 static void copy_framebuffer() {
     uint32_t *src = (uint32_t*)(umac_ram + umac_get_fb_offset());
-#if DISP_WIDTH==640 && DISP_HEIGHT==480
-    uint32_t *dest = umac_framebuffer_mirror;
-    for(int i=0; i<640*480/32; i++) {
-        *dest++ = *src++;
-    }
-#elif DISP_WIDTH==512 && DISP_HEIGHT==342
+#if DISP_WIDTH==512 && DISP_HEIGHT==342
     #define DISP_XOFFSET ((640 - DISP_WIDTH) / 32 / 2)
     #define DISP_YOFFSET ((480 - DISP_HEIGHT) / 2)
     #define LONGS_PER_INPUT_ROW (DISP_WIDTH / 32)
@@ -135,11 +139,14 @@ static void copy_framebuffer() {
     for(int i=0; i<DISP_HEIGHT; i++) {
         uint32_t *dest = umac_framebuffer_mirror + (DISP_YOFFSET * LONGS_PER_OUTPUT_ROW + DISP_XOFFSET) + LONGS_PER_OUTPUT_ROW * i;
         for(int j=0; j<LONGS_PER_INPUT_ROW; j++) {
-          *dest++ = *src++ ^ 0xffffffff;
+          *dest++ = *src++;
         }
     }
 #else
-#error Unsupported display geometry for framebuffer mirroring
+    uint32_t *dest = umac_framebuffer_mirror;
+    for(int i=0; i<DISP_WIDTH*DISP_HEIGHT/32; i++) {
+        *dest++ = *src++;
+    }
 #endif
 }
 #endif
@@ -320,9 +327,17 @@ static void     core1_main()
          * core 0's USB activity.
          */
 #if MIRROR_FRAMEBUFFER
-        video_init((uint32_t *)(umac_framebuffer_mirror), 640, 480, 60);
+        uint32_t *fb = (uint32_t *)(umac_framebuffer_mirror);
 #else
-        video_init((uint32_t *)(umac_ram + umac_get_fb_offset()), 640, 480, 60);
+        uint32_t *fb = (uint32_t *)(umac_ram + umac_get_fb_offset());
+#endif
+
+#if DISP_WIDTH < 640
+        video_init(fb, 640, 480, 60);
+#elif DISP_WIDTH >= 1024
+        video_init(fb, DISP_WIDTH, DISP_HEIGHT, 50);
+#else
+        video_init(fb, DISP_WIDTH, DISP_HEIGHT, 60);
 #endif
 
 #if ENABLE_AUDIO

--- a/src/video_hstx.c
+++ b/src/video_hstx.c
@@ -22,7 +22,9 @@
  * THE SOFTWARE.
  */
 
-#include "stdlib.h"
+#include <math.h>
+#include <stdlib.h>
+#include <stdio.h>
 
 // This is from: https://github.com/raspberrypi/pico-examples-rp2350/blob/a1/hstx/dvi_out_hstx_encoder/dvi_out_hstx_encoder.c
 
@@ -31,6 +33,10 @@
 #include "hardware/structs/bus_ctrl.h"
 #include "hardware/structs/hstx_ctrl.h"
 #include "hardware/structs/hstx_fifo.h"
+
+#include "clocking.h"
+#include "gtf.h"
+#include "video.h"
 
 // ----------------------------------------------------------------------------
 // DVI constants
@@ -44,27 +50,6 @@
 #define SYNC_V0_H1 (TMDS_CTRL_01 | (TMDS_CTRL_00 << 10) | (TMDS_CTRL_00 << 20))
 #define SYNC_V1_H0 (TMDS_CTRL_10 | (TMDS_CTRL_00 << 10) | (TMDS_CTRL_00 << 20))
 #define SYNC_V1_H1 (TMDS_CTRL_11 | (TMDS_CTRL_00 << 10) | (TMDS_CTRL_00 << 20))
-
-#define MODE_H_SYNC_POLARITY 0
-#define MODE_H_FRONT_PORCH   16
-#define MODE_H_SYNC_WIDTH    96
-#define MODE_H_BACK_PORCH    48
-#define MODE_H_ACTIVE_PIXELS 640
-
-#define MODE_V_SYNC_POLARITY 0
-#define MODE_V_FRONT_PORCH   10
-#define MODE_V_SYNC_WIDTH    2
-#define MODE_V_BACK_PORCH    33
-#define MODE_V_ACTIVE_LINES  480
-
-#define MODE_H_TOTAL_PIXELS ( \
-    MODE_H_FRONT_PORCH + MODE_H_SYNC_WIDTH + \
-    MODE_H_BACK_PORCH + MODE_H_ACTIVE_PIXELS \
-    )
-#define MODE_V_TOTAL_LINES  ( \
-    MODE_V_FRONT_PORCH + MODE_V_SYNC_WIDTH + \
-    MODE_V_BACK_PORCH + MODE_V_ACTIVE_LINES \
-    )
 
 #define HSTX_CMD_RAW         (0x0u << 12)
 #define HSTX_CMD_RAW_REPEAT  (0x1u << 12)
@@ -87,34 +72,35 @@
 // ----------------------------------------------------------------------------
 // HSTX command lists
 
+// These need to be in SRAM (for DMA) but also because we change them at runtime
 static uint32_t vblank_line_vsync_off[] = {
-    BSWAP_MAYBE(HSTX_CMD_RAW_REPEAT | MODE_H_FRONT_PORCH),
+    BSWAP_MAYBE(HSTX_CMD_RAW_REPEAT /* | MODE_H_FRONT_PORCH) */),
     BSWAP_MAYBE(SYNC_V1_H1),
-    BSWAP_MAYBE(HSTX_CMD_RAW_REPEAT | MODE_H_SYNC_WIDTH),
+    BSWAP_MAYBE(HSTX_CMD_RAW_REPEAT /* | MODE_H_SYNC_WIDTH) */),
     BSWAP_MAYBE(SYNC_V1_H0),
-    BSWAP_MAYBE(HSTX_CMD_RAW_REPEAT | (MODE_H_BACK_PORCH + MODE_H_ACTIVE_PIXELS)),
+    BSWAP_MAYBE(HSTX_CMD_RAW_REPEAT /* | (MODE_H_BACK_PORCH + MODE_H_ACTIVE_PIXELS)) */),
     BSWAP_MAYBE(SYNC_V1_H1),
 };
 
 static uint32_t vblank_line_vsync_on[] = {
-    BSWAP_MAYBE(HSTX_CMD_RAW_REPEAT | MODE_H_FRONT_PORCH),
+    BSWAP_MAYBE(HSTX_CMD_RAW_REPEAT /* | MODE_H_FRONT_PORCH) */),
     BSWAP_MAYBE(SYNC_V0_H1),
-    BSWAP_MAYBE(HSTX_CMD_RAW_REPEAT | MODE_H_SYNC_WIDTH),
+    BSWAP_MAYBE(HSTX_CMD_RAW_REPEAT /* | MODE_H_SYNC_WIDTH) */),
     BSWAP_MAYBE(SYNC_V0_H0),
-    BSWAP_MAYBE(HSTX_CMD_RAW_REPEAT | (MODE_H_BACK_PORCH + MODE_H_ACTIVE_PIXELS)),
+    BSWAP_MAYBE(HSTX_CMD_RAW_REPEAT /* | (MODE_H_BACK_PORCH + MODE_H_ACTIVE_PIXELS)) */),
     BSWAP_MAYBE(SYNC_V0_H1),
 };
 
 static uint32_t vactive_line[] = {
-    BSWAP_MAYBE(HSTX_CMD_RAW_REPEAT | MODE_H_FRONT_PORCH),
+    BSWAP_MAYBE(HSTX_CMD_RAW_REPEAT /* | MODE_H_FRONT_PORCH) */),
     BSWAP_MAYBE(SYNC_V1_H1),
     BSWAP_MAYBE(HSTX_CMD_NOP),
-    BSWAP_MAYBE(HSTX_CMD_RAW_REPEAT | MODE_H_SYNC_WIDTH),
+    BSWAP_MAYBE(HSTX_CMD_RAW_REPEAT /* | MODE_H_SYNC_WIDTH) */),
     BSWAP_MAYBE(SYNC_V1_H0),
     BSWAP_MAYBE(HSTX_CMD_NOP),
-    BSWAP_MAYBE(HSTX_CMD_RAW_REPEAT | MODE_H_BACK_PORCH),
+    BSWAP_MAYBE(HSTX_CMD_RAW_REPEAT /* | MODE_H_BACK_PORCH) */),
     BSWAP_MAYBE(SYNC_V1_H1),
-    BSWAP_MAYBE(HSTX_CMD_TMDS | MODE_H_ACTIVE_PIXELS),
+    BSWAP_MAYBE(HSTX_CMD_TMDS /* | MODE_H_ACTIVE_PIXELS) */),
 };
 
 typedef struct {
@@ -141,18 +127,48 @@ static void __not_in_flash_func(dma_irq_handler)(void) {
     ch->al3_read_addr_trig = (uintptr_t)active_picodvi->dma_commands;
 }
 
-#define REAL_DISP_WIDTH 640
-#define REAL_DISP_HEIGHT 480
-
-void    video_init(uint32_t *framebuffer) {
+__attribute__((optimize("O0")))
+void    video_init(uint32_t *framebuffer, int width, int height, float refresh) {
     picodvi_framebuffer_obj_t *self = &picodvi;
+
+    gtf_mode_t mode;
+    gtf_calculate(&mode, width, height, refresh);
+
+    hstx_clock_hz(rint(mode.pclk * 1000 * 1000 /* Hz to Hz */ * 10 /* pixel to bits */ ));
+
+    int v_total_lines = mode.vfl;
+    int v_active_lines = mode.vr;
+    int v_front_porch = mode.vss - mode.vr;
+    int v_back_porch = mode.vfl - mode.vse;
+    int v_sync_width = mode.vse - mode.vss;
+
+printf("v % 4d % 4d % 4d % 4d [% 4d]\n", v_active_lines, v_front_porch, v_sync_width, v_back_porch, v_total_lines);
+    int h_total_pixels = mode.hfl;
+    int h_active_pixels = mode.hr;
+    int h_front_porch = mode.hss - mode.hr;
+    int h_back_porch = mode.hfl - mode.hse;
+    int h_sync_width = mode.hse - mode.hss;
+printf("h % 4d % 4d % 4d % 4d [% 4d]\n", h_active_pixels, h_front_porch, h_sync_width, h_back_porch, h_total_pixels);
+
+    vblank_line_vsync_off[0] = BSWAP_MAYBE(HSTX_CMD_RAW_REPEAT | h_front_porch);
+    vblank_line_vsync_off[2] = BSWAP_MAYBE(HSTX_CMD_RAW_REPEAT | h_sync_width);
+    vblank_line_vsync_off[4] = BSWAP_MAYBE(HSTX_CMD_RAW_REPEAT | h_back_porch + h_active_pixels);
+
+    vblank_line_vsync_on[0] = BSWAP_MAYBE(HSTX_CMD_RAW_REPEAT | h_front_porch);
+    vblank_line_vsync_on[2] = BSWAP_MAYBE(HSTX_CMD_RAW_REPEAT | h_sync_width);
+    vblank_line_vsync_on[4] = BSWAP_MAYBE(HSTX_CMD_RAW_REPEAT | h_back_porch + h_active_pixels);
+
+    vactive_line[0] = BSWAP_MAYBE(HSTX_CMD_RAW_REPEAT | h_front_porch);
+    vactive_line[3] = BSWAP_MAYBE(HSTX_CMD_RAW_REPEAT | h_sync_width);
+    vactive_line[6] = BSWAP_MAYBE(HSTX_CMD_RAW_REPEAT | h_back_porch);
+    vactive_line[8] = BSWAP_MAYBE(HSTX_CMD_TMDS | h_active_pixels);
 
     // We compute all DMA transfers needed for a single frame. This ensure we don't have any super
     // quick interrupts that we need to respond to. Each transfer takes two words, trans_count and
     // read_addr. Active pixel lines need two transfers due to different read addresses. When pixel
     // doubling, then we must also set transfer size.
     size_t dma_command_size = 2;
-    self->dma_commands_len = (MODE_V_FRONT_PORCH + MODE_V_SYNC_WIDTH + MODE_V_BACK_PORCH + 2 * MODE_V_ACTIVE_LINES + 1) * dma_command_size;
+    self->dma_commands_len = (v_front_porch + v_sync_width + v_back_porch + 2 * v_active_lines + 1) * dma_command_size;
     self->dma_commands = (uint32_t *)malloc(self->dma_commands_len * sizeof(uint32_t));
     if (self->dma_commands == NULL) {
         return;
@@ -162,17 +178,17 @@ void    video_init(uint32_t *framebuffer) {
     self->dma_command_channel = dma_claim_unused_channel(true);
 
     size_t pixels_per_word = 32;
-    size_t words_per_line = REAL_DISP_WIDTH / pixels_per_word;
+    size_t words_per_line = width / pixels_per_word;
     uint8_t rot = 24; // 24 + color_depth;
     size_t shift_amount = 31; // color_depth % 32;
 
     size_t command_word = 0;
-    size_t frontporch_start = MODE_V_TOTAL_LINES - MODE_V_FRONT_PORCH;
-    size_t frontporch_end = frontporch_start + MODE_V_FRONT_PORCH;
+    size_t frontporch_start = v_total_lines - v_front_porch;
+    size_t frontporch_end = frontporch_start + v_front_porch;
     size_t vsync_start = 0;
-    size_t vsync_end = vsync_start + MODE_V_SYNC_WIDTH;
+    size_t vsync_end = vsync_start + v_sync_width;
     size_t backporch_start = vsync_end;
-    size_t backporch_end = backporch_start + MODE_V_BACK_PORCH;
+    size_t backporch_end = backporch_start + v_back_porch;
     size_t active_start = backporch_end;
 
     uint32_t dma_ctrl = (self->dma_command_channel << DMA_CH0_CTRL_TRIG_CHAIN_TO_LSB) |
@@ -193,7 +209,7 @@ void    video_init(uint32_t *framebuffer) {
     dma_channel_hw_addr(self->dma_pixel_channel)->al1_ctrl = dma_pixel_ctrl;
     dma_channel_hw_addr(self->dma_pixel_channel)->al1_write_addr = dma_write_addr;
 
-    for (size_t v_scanline = 0; v_scanline < MODE_V_TOTAL_LINES; v_scanline++) {
+    for (size_t v_scanline = 0; v_scanline < v_total_lines; v_scanline++) {
         if (vsync_start <= v_scanline && v_scanline < vsync_end) {
             self->dma_commands[command_word++] = count_of(vblank_line_vsync_on);
             self->dma_commands[command_word++] = (uintptr_t)vblank_line_vsync_on;
@@ -209,7 +225,7 @@ void    video_init(uint32_t *framebuffer) {
             size_t row = v_scanline - active_start;
             size_t transfer_count = words_per_line;
             self->dma_commands[command_word++] = transfer_count;
-            uintptr_t row_start = row * (REAL_DISP_WIDTH / 8) + (uintptr_t)framebuffer;
+            uintptr_t row_start = row * (width / 8) + (uintptr_t)framebuffer;
             self->dma_commands[command_word++] = row_start;
         }
     }


### PR DESCRIPTION
Tested at 800x480 and 1280x720 (HD!) using https://www.adafruit.com/product/1667 as the display.

This increases the overvoltage from 1.15V to 1.20V and changes the PSRAM timing slightly, which made the overclocked PSRAM version stable on my Fruit Jam. 1.20V is still within the datasheet specified range.

It's worth noting that *this specific Fruit Jam* has spent several days with the much higher overvolt/overclock of the fruitjam 286 emulator (VREG_VOLTAGE_1_60 + 376MHz core) and it may have been damaged due to this. 1.60V is well beyond the datasheet maximum core voltage. I don't know how to confirm/refute this supposition, but as 1.20V is within the datasheet specs I am not too worried about it.
